### PR TITLE
chore: investigate 4892

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "scripts": {
     "test": "vitest"
   },
+  "dependencies": {
+    "loupe": "2.3.6"
+  },
   "devDependencies": {
     "@vitest/browser": "^1.2.1",
     "playwright": "^1.41.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+dependencies:
+  loupe:
+    specifier: 2.3.6
+    version: 2.3.6
+
 devDependencies:
   '@vitest/browser':
     specifier: ^1.2.1
@@ -562,7 +567,6 @@ packages:
 
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
-    dev: true
 
   /get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
@@ -594,6 +598,13 @@ packages:
       mlly: 1.5.0
       pkg-types: 1.0.3
     dev: true
+
+  /loupe@2.3.6:
+    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
+    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
+    dependencies:
+      get-func-name: 2.0.2
+    dev: false
 
   /loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}

--- a/test/repro.test.ts
+++ b/test/repro.test.ts
@@ -1,4 +1,6 @@
-import { test } from 'vitest';
+import { test, expect } from 'vitest';
+import loupe from "loupe"
 
 test('ok', async () => {
+  expect(loupe).toBeDefined();
 });

--- a/test/repro.test.ts
+++ b/test/repro.test.ts
@@ -1,6 +1,9 @@
 import { test, expect } from 'vitest';
-import loupe from "loupe"
+// actually importing would somehow avoid error...
+// https://github.com/vitest-dev/vitest/issues/4892#issuecomment-1907879517
+// import loupe from "loupe"
 
 test('ok', async () => {
-  expect(loupe).toBeDefined();
+  // expect(loupe).toBeDefined();
+  expect(0).toBe(0);
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   optimizeDeps: {
     // debug by
     //   DEBUG=vite:deps pnpm test
-    // force: true
+    force: true
   },
   test: {
     browser: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  optimizeDeps: {
+    // debug by
+    //   DEBUG=vite:deps pnpm test
+    // force: true
+  },
   test: {
     browser: {
       enabled: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,19 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   optimizeDeps: {
     // debug by
     //   DEBUG=vite:deps pnpm test
-    force: true
+    force: true,
+    // tweak optimizeDeps for browser tests
+    // https://github.com/vitest-dev/vitest/issues/4892#issuecomment-1907879517
+    include: ["vitest > @vitest/utils > loupe"],
   },
   test: {
     browser: {
       enabled: true,
       provider: "playwright",
-      name: 'chromium',
+      name: "chromium",
     },
   },
 });


### PR DESCRIPTION
It looks still working even when having a different version of `loupe` is used. The content of `node_modules/.vite/deps/_metadata.json` looks like this:

<details><summary>Reveal json</summary>

```json
{
  "hash": "6c1623ab",
  "configHash": "eb40bf53",
  "lockfileHash": "1cc89883",
  "browserHash": "374c66da",
  "optimized": {
    "vitest > @vitest/utils > pretty-format": {
      "src": "../../.pnpm/pretty-format@29.7.0/node_modules/pretty-format/build/index.js",
      "file": "vitest___@vitest_utils___pretty-format.js",
      "fileHash": "ba1674d7",
      "needsInterop": true
    },
    "vitest > @vitest/snapshot > pretty-format": {
      "src": "../../.pnpm/pretty-format@29.7.0/node_modules/pretty-format/build/index.js",
      "file": "vitest___@vitest_snapshot___pretty-format.js",
      "fileHash": "cea6b5a6",
      "needsInterop": true
    },
    "vitest > diff-sequences": {
      "src": "../../.pnpm/diff-sequences@29.6.3/node_modules/diff-sequences/build/index.js",
      "file": "vitest___diff-sequences.js",
      "fileHash": "5a5cb062",
      "needsInterop": true
    },
    "vitest > loupe": {
      "src": "../../.pnpm/loupe@2.3.7/node_modules/loupe/loupe.js",
      "file": "vitest___loupe.js",
      "fileHash": "a8de38a4",
      "needsInterop": true
    },
    "vitest > pretty-format": {
      "src": "../../.pnpm/pretty-format@29.7.0/node_modules/pretty-format/build/index.js",
      "file": "vitest___pretty-format.js",
      "fileHash": "18dad702",
      "needsInterop": true
    },
    "vitest > pretty-format > ansi-styles": {
      "src": "../../.pnpm/ansi-styles@5.2.0/node_modules/ansi-styles/index.js",
      "file": "vitest___pretty-format___ansi-styles.js",
      "fileHash": "60bffdac",
      "needsInterop": true
    },
    "vitest > chai": {
      "src": "../../.pnpm/chai@4.4.1/node_modules/chai/index.mjs",
      "file": "vitest___chai.js",
      "fileHash": "c1950c19",
      "needsInterop": false
    },
    "loupe": {
      "src": "../../.pnpm/loupe@2.3.6/node_modules/loupe/loupe.js",
      "file": "loupe.js",
      "fileHash": "638862d6",
      "needsInterop": true
    }
  },
  "chunks": {
    "chunk-LOVO3CBA": {
      "file": "chunk-LOVO3CBA.js"
    },
    "chunk-IIIR3MIJ": {
      "file": "chunk-IIIR3MIJ.js"
    },
    "chunk-UFGDH22V": {
      "file": "chunk-UFGDH22V.js"
    },
    "chunk-QX33BESJ": {
      "file": "chunk-QX33BESJ.js"
    },
    "chunk-LQ2VYIYD": {
      "file": "chunk-LQ2VYIYD.js"
    }
  }
}
```

</details>


Also the log when running with `optimizeDeps.force` and `DEBUG=vite:deps`:

<details><summary>Reveal log</summary>

```
$ DEBUG=vite:deps pnpm test 

> @ test /home/hiroshi/Downloads/repro-vitest-browser-basic
> vitest

  vite:deps removing old cache dir /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vite/deps +0ms
  vite:deps scanning for dependencies... +0ms
  vite:deps Crawling dependencies using entries: 
  vite:deps   /home/hiroshi/Downloads/repro-vitest-browser-basic/test/repro.test.ts +0ms
  vite:deps removing old cache dir /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vitest/deps +26ms
  vite:deps creating package.json in /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vitest/deps_temp_d2004999 +2ms
  vite:deps creating _metadata.json in /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vitest/deps_temp_d2004999 +1ms
  vite:deps renaming /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vitest/deps_temp_d2004999 to /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vitest/deps +0ms
  vite:deps ✨ dependencies optimized +21ms
  vite:deps Scan completed in 27.91ms: 
  vite:deps   loupe -> /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.pnpm/loupe@2.3.6/node_modules/loupe/loupe.js +18ms
  vite:deps creating package.json in /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vite/deps_temp_dedae055 +8ms

 DEV  v1.2.1 /home/hiroshi/Downloads/repro-vitest-browser-basic
      Browser runner started at http://localhost:5173/

  vite:deps Dependencies bundled in 192.74ms +193ms
  vite:deps ✨ static imports crawl ended +840ms
  vite:deps ✨ using post-scan optimizer result, the scanner found every used dependency +1ms
  vite:deps creating _metadata.json in /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vite/deps_temp_dedae055 +640ms
  vite:deps renaming /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vite/deps_temp_dedae055 to /home/hiroshi/Downloads/repro-vitest-browser-basic/node_modules/.vite/deps +0ms
  vite:deps ✨ dependencies optimized +0ms
```

</details>